### PR TITLE
project: Replace crypto dependencies with Botan

### DIFF
--- a/project.html
+++ b/project.html
@@ -62,11 +62,9 @@ by anyone while still offering advanced features to those that need them.</p>
     <p>KeePassXC has the following runtime requirements:
     <ul>
         <li>Qt5 (5.6 or newer)</li>
-        <li>libgcrypt (1.8 or newer)</li>
-        <li>libargon2</li>
+        <li>Botan (2.11.0 or newer)</li>
         <li>libquazip5</li>
         <li>libqrencode</li>
-        <li>libsodium</li>
         <li>zlib1g</li>
         <li>zlib</li>
         <li>libxi, libxtst, qtx11extras (optional, for Auto-Type on X11/Linux)</li>


### PR DESCRIPTION
Since 2.7.0-beta1, libargon, gcrypt, and sodium are replaced with Botan.

Ref: https://github.com/keepassxreboot/keepassxc/commit/80809ace677a920b62be2259c1156d419adcdb97